### PR TITLE
Add correct_capitalization parameter to markdown2docx endpoint

### DIFF
--- a/function_app.py
+++ b/function_app.py
@@ -66,6 +66,7 @@ async def markdown2docx(req: functions.HttpRequest) -> functions.HttpResponse:
     """
     body_dict = json.loads(req.get_body().decode("utf-8"))
     correct_they = body_dict.get("correct_they", False)
+    correct_capitalization = body_dict.get("correct_capitalization", False)
     markdown = body_dict.get("markdown", None)
     if not markdown:
         return functions.HttpResponse(
@@ -73,7 +74,9 @@ async def markdown2docx(req: functions.HttpRequest) -> functions.HttpResponse:
             status_code=http.HTTPStatus.BAD_REQUEST,
         )
     docx_bytes = file_conversion_controller.markdown2docx(
-        markdown, correct_they=correct_they
+        markdown,
+        correct_they=correct_they,
+        correct_capitalization=correct_capitalization,
     )
     return functions.HttpResponse(
         body=docx_bytes,

--- a/function_app.py
+++ b/function_app.py
@@ -65,8 +65,8 @@ async def markdown2docx(req: functions.HttpRequest) -> functions.HttpResponse:
         The HTTP response containing the .docx file.
     """
     body_dict = json.loads(req.get_body().decode("utf-8"))
-    correct_they = body_dict.get("correct_they", False)
-    correct_capitalization = body_dict.get("correct_capitalization", False)
+    correct_they = body_dict.get("X-Correct-They", False)
+    correct_capitalization = body_dict.get("X-Correct-Capitalization", False)
     markdown = body_dict.get("markdown", None)
     if not markdown:
         return functions.HttpResponse(

--- a/src/ctk_functions/functions/file_conversion/controller.py
+++ b/src/ctk_functions/functions/file_conversion/controller.py
@@ -7,18 +7,23 @@ import pypandoc
 from ctk_functions.text import corrections
 
 
-def markdown2docx(markdown: str, *, correct_they: bool = False) -> bytes:
+def markdown2docx(
+    markdown: str, *, correct_they: bool = False, correct_capitalization: bool = False
+) -> bytes:
     """Converts a Markdown document to a .docx file.
 
     Args:
         markdown: The Markdown document.
         correct_they: Whether to correct verb conjugations associated with 'they'.
+        correct_capitalization: Whether to correct the capitalization of the text.
 
     Returns:
         The .docx file.
     """
-    if correct_they and "they" in markdown.lower():
-        markdown = corrections.TextCorrections(correct_they=True).correct(markdown)
+    if correct_they or correct_capitalization:
+        markdown = corrections.TextCorrections(
+            correct_they=correct_they, correct_capitalization=correct_capitalization
+        ).correct(markdown)
 
     with tempfile.NamedTemporaryFile(suffix=".docx") as temp_file:
         pypandoc.convert_text(
@@ -26,7 +31,6 @@ def markdown2docx(markdown: str, *, correct_they: bool = False) -> bytes:
             "docx",
             format="md",
             outputfile=temp_file.name,
-            extra_args=["-f", "markdown+grid_tables"],
         )
         temp_file.seek(0)
         return temp_file.read()


### PR DESCRIPTION
This pull request adds a new parameter, `correct_capitalization`, to the `markdown2docx` endpoint. 