### PR TITLE
Mark warnings as red in docx files

### DIFF
--- a/src/ctk_functions/functions/file_conversion/controller.py
+++ b/src/ctk_functions/functions/file_conversion/controller.py
@@ -1,7 +1,10 @@
 """Functions for converting files between different formats."""
 
+import re
 import tempfile
 
+import cmi_docx
+import docx
 import pypandoc
 
 from ctk_functions.text import corrections
@@ -33,4 +36,23 @@ def markdown2docx(
             outputfile=temp_file.name,
         )
         temp_file.seek(0)
+        mark_warnings_as_red(temp_file.name)
         return temp_file.read()
+
+
+def mark_warnings_as_red(docx_file: str) -> None:
+    """Marks warning templates as red.
+
+    We use {{!WARNING-TEXT}} as a template for warnings that should be marked red.
+
+    Args:
+        docx_file: The .docx file.
+    """
+    document = docx.Document(docx_file)
+    extend_document = cmi_docx.ExtendDocument(document)
+    text = "\n".join([paragraph.text for paragraph in document.paragraphs])
+    warningRegex = re.compile(r"{{!.*?}}")
+    matches = set(warningRegex.finditer(text))
+    for match in matches:
+        extend_document.replace(match.group(), match.group(), {"font_rgb": (255, 0, 0)})
+    document.save(docx_file)

--- a/tests/unit/test_file_conversion_controller.py
+++ b/tests/unit/test_file_conversion_controller.py
@@ -1,0 +1,48 @@
+"""Tests for the file conversion controller."""
+
+import pathlib
+
+import docx
+from docx.text import run
+
+from ctk_functions.functions.file_conversion import controller
+
+
+def is_run_font_color_red(run: run.Run) -> bool:
+    """Checks if the font color of a run is red."""
+    return '<w:color w:val="FF0000"' in str(run.font.color.element.xml)
+
+
+def test_mark_warnings_as_red(tmp_path: pathlib.Path) -> None:
+    """Tests marking warning labels as red."""
+    filename = tmp_path / "test.docx"
+    doc = docx.Document()
+    doc.add_paragraph("This is a {{!WARNING-TEXT}}.")
+    doc.add_paragraph("Another {{!WARNING-TEXT-2}} here.")
+    doc.save(str(filename))
+
+    controller.mark_warnings_as_red(filename)
+    modified_doc = docx.Document(filename)
+
+    assert modified_doc.paragraphs[0].runs[1].text == "{{!WARNING-TEXT}}"
+    assert modified_doc.paragraphs[1].runs[1].text == "{{!WARNING-TEXT-2}}"
+    assert not is_run_font_color_red(modified_doc.paragraphs[0].runs[0])
+    assert is_run_font_color_red(modified_doc.paragraphs[0].runs[1])
+    assert is_run_font_color_red(modified_doc.paragraphs[1].runs[1])
+
+
+def test_markdown2docx(tmp_path: pathlib.Path) -> None:
+    """Tests the conversion of Markdown to docx."""
+    markdown = "# Header\n\nThis is a paragraph.\n\nThis is a {{!WARNING-TEXT}}."
+
+    docx_bytes = controller.markdown2docx(markdown)
+    filename = tmp_path / "test.docx"
+    with open(filename, "wb") as file:
+        file.write(docx_bytes)
+    doc = docx.Document(filename)
+
+    assert doc.paragraphs[0].text == "Header"
+    assert doc.paragraphs[1].text == "This is a paragraph."
+    assert doc.paragraphs[2].runs[1].text == "{{!WARNING-TEXT}}"
+    assert not is_run_font_color_red(doc.paragraphs[2].runs[0])
+    assert is_run_font_color_red(doc.paragraphs[2].runs[1])


### PR DESCRIPTION
This pull request adds a new function `mark_warnings_as_red` to the file conversion controller. This function marks warning templates in docx files as red. 