### PR TITLE
fix: warning labels no longer replicate

### DIFF
--- a/src/ctk_functions/functions/file_conversion/controller.py
+++ b/src/ctk_functions/functions/file_conversion/controller.py
@@ -57,7 +57,10 @@ def mark_warnings_as_red(docx_file: str | pathlib.Path) -> None:
     extend_document = cmi_docx.ExtendDocument(document)
     text = "\n".join([paragraph.text for paragraph in document.paragraphs])
     warningRegex = re.compile(r"{{!.*?}}")
-    matches = set(warningRegex.finditer(text))
-    for match in matches:
-        extend_document.replace(match.group(), match.group(), {"font_rgb": (255, 0, 0)})
+    matches = warningRegex.finditer(text)
+    uniqueMatches = set([match.group() for match in matches])
+
+    for match in uniqueMatches:
+        extend_document.replace(match, match, {"font_rgb": (255, 0, 0)})
+
     document.save(str(docx_file))

--- a/tests/unit/test_file_conversion_controller.py
+++ b/tests/unit/test_file_conversion_controller.py
@@ -17,13 +17,19 @@ def test_mark_warnings_as_red(tmp_path: pathlib.Path) -> None:
     """Tests marking warning labels as red."""
     filename = tmp_path / "test.docx"
     doc = docx.Document()
-    doc.add_paragraph("This is a {{!WARNING-TEXT}}.")
-    doc.add_paragraph("Another {{!WARNING-TEXT-2}} here.")
+    sentences = [
+        "This is a {{!WARNING-TEXT}}.",
+        "Another {{!WARNING-TEXT-2}} {{!WARNING-TEXT}} here.",
+    ]
+    doc.add_paragraph(sentences[0])
+    doc.add_paragraph(sentences[1])
     doc.save(str(filename))
 
     controller.mark_warnings_as_red(filename)
     modified_doc = docx.Document(str(filename))
 
+    assert modified_doc.paragraphs[0].text == sentences[0]
+    assert modified_doc.paragraphs[1].text == sentences[1]
     assert modified_doc.paragraphs[0].runs[1].text == "{{!WARNING-TEXT}}"
     assert modified_doc.paragraphs[1].runs[1].text == "{{!WARNING-TEXT-2}}"
     assert not is_run_font_color_red(modified_doc.paragraphs[0].runs[0])


### PR DESCRIPTION
This pull request fixes an issue where warning labels were being replicated in the document. 