### PR TITLE
feat: Add support for the title field

### DIFF
--- a/src/ctk_functions/microservices/redcap.py
+++ b/src/ctk_functions/microservices/redcap.py
@@ -65,6 +65,15 @@ class GuardianRelationship(enum.Enum):
     other = 12
 
 
+class GuardianTitle(enum.Enum):
+    """The guardian's title."""
+
+    Mr = "1"
+    Mrs = "2"
+    Ms = "3"
+    Other = "4"
+
+
 class SchoolType(enum.Enum):
     """The type of school the patient attends."""
 
@@ -653,6 +662,8 @@ class RedCapData(pydantic.BaseModel):
 
     # Guardian
 
+    title: GuardianTitle | None
+    title_other: str | None
     guardian_first_name: str
     guardian_last_name: str
     guardian_maritalstatus: GuardianMaritalStatus
@@ -1476,4 +1487,5 @@ def get_intake_data(mrn: str) -> RedCapData:
             records=[record_ids[0]],
         ),
     )
+
     return RedCapData.from_csv(patient_data)

--- a/src/ctk_functions/microservices/redcap.py
+++ b/src/ctk_functions/microservices/redcap.py
@@ -662,8 +662,8 @@ class RedCapData(pydantic.BaseModel):
 
     # Guardian
 
-    title: GuardianTitle | None
-    title_other: str | None
+    title: GuardianTitle | None = None
+    title_other: str | None = None
     guardian_first_name: str
     guardian_last_name: str
     guardian_maritalstatus: GuardianMaritalStatus

--- a/src/ctk_functions/routers/intake/intake_processing/parser.py
+++ b/src/ctk_functions/routers/intake/intake_processing/parser.py
@@ -182,6 +182,7 @@ class PersonalRelation(abc.ABC):
     first_name: str
     last_name: str
     relationship: str
+    _title: str | None = None
 
     @property
     def title_name(self) -> str:
@@ -203,6 +204,9 @@ class PersonalRelation(abc.ABC):
         Returns:
             str: The title of the relationship based on their inferred gender.
         """
+        if self._title:
+            return self._title
+
         female_keywords = ["mother", "aunt", "carrier", "sister"]
         male_keywords = ["father", "uncle", "brother"]
 
@@ -211,14 +215,6 @@ class PersonalRelation(abc.ABC):
         if any(keyword in self.relationship.lower() for keyword in female_keywords):
             return "Ms./Mrs."
         return "Mr./Ms./Mrs."
-
-    @property
-    def parent_or_guardian(self) -> str:
-        """The parent or guardian."""
-        parent_keywords = ["mother", "father"]
-        if any(keyword in self.relationship.lower() for keyword in parent_keywords):
-            return "parent"
-        return "guardian"
 
 
 class Guardian(PersonalRelation):
@@ -233,6 +229,12 @@ class Guardian(PersonalRelation):
         logger.debug("Parsing guardian information.")
         self.first_name = all_caps_to_title(patient_data.guardian_first_name)
         self.last_name = all_caps_to_title(patient_data.guardian_last_name)
+
+        if patient_data.title == redcap.GuardianTitle.Other:
+            self._title = patient_data.title_other
+        elif patient_data.title:
+            self._title = patient_data.title.name + "."
+
         if patient_data.guardian_relationship == redcap.GuardianRelationship.other:
             self.relationship = patient_data.other_relation or "NOT PROVIDED"
         else:
@@ -240,6 +242,14 @@ class Guardian(PersonalRelation):
                 "_",
                 " ",
             )
+
+    @property
+    def parent_or_guardian(self) -> str:
+        """The parent or guardian."""
+        parent_keywords = ["mother", "father"]
+        if any(keyword in self.relationship.lower() for keyword in parent_keywords):
+            return "parent"
+        return "guardian"
 
 
 class Household:

--- a/src/ctk_functions/routers/intake/intake_processing/parser.py
+++ b/src/ctk_functions/routers/intake/intake_processing/parser.py
@@ -177,7 +177,15 @@ class Patient:
 
 
 class PersonalRelation(abc.ABC):
-    """Basic string properties for personal relationships."""
+    """Basic string properties for personal relationships.
+
+    Attributes:
+        first_name: The first name of the person.
+        last_name: The last name of the person.
+        relationship: The relationship to the patient.
+        _title: Optional title. If None provided, it is inferred from the
+            relationship.
+    """
 
     first_name: str
     last_name: str

--- a/tests/unit/test_intake_parser.py
+++ b/tests/unit/test_intake_parser.py
@@ -35,6 +35,37 @@ def test_guardian_parser_other_relationship(
     assert guardian.relationship == test_redcap_data.other_relation
 
 
+def test_guardian_parser_title(
+    test_redcap_data: redcap.RedCapData,
+) -> None:
+    """Tests default title parsing."""
+    test_redcap_data = test_redcap_data.model_copy(
+        update={
+            "title": redcap.GuardianTitle.Mr,
+        },
+    )
+
+    guardian = parser.Guardian(test_redcap_data)
+
+    assert guardian.title == "Mr."
+
+
+def test_guardian_parser_title_other(
+    test_redcap_data: redcap.RedCapData,
+) -> None:
+    """Tests other title parsing.."""
+    test_redcap_data = test_redcap_data.model_copy(
+        update={
+            "title": redcap.GuardianTitle.Other,
+            "title_other": "Jedi",
+        },
+    )
+
+    guardian = parser.Guardian(test_redcap_data)
+
+    assert guardian.title == "Jedi"
+
+
 def test_household_parser(
     test_redcap_data: redcap.RedCapData,
 ) -> None:


### PR DESCRIPTION
The intake forms now include a title field, so we no longer need to infer the title from the guardian's relationship to the child. This PR adds support for this new field, whilst retaining compatibility with old intake forms where this field does not exist. 

Along the way, I made a minor fix of moving the parent_or_guardian method away from the Household relation abstract baseclass to the Guardian class. This method should only ever be used on the guardian object. 