### PR TITLE
fix: Reduce LLM reporting months when no month is reported.

### DIFF
--- a/src/ctk_functions/routers/intake/intake_processing/writer.py
+++ b/src/ctk_functions/routers/intake/intake_processing/writer.py
@@ -1009,6 +1009,7 @@ class ReportWriter:
                 comment="\n\n".join(
                     [str(intervention) for intervention in interventions],
                 ),
+                verify=True,
             )
 
         self._insert("Past Therapeutic Interventions", _StyleName.HEADING_2)

--- a/src/ctk_functions/routers/intake/intake_processing/writer_llm.py
+++ b/src/ctk_functions/routers/intake/intake_processing/writer_llm.py
@@ -54,7 +54,7 @@ requirements:
 - Do not use quotations; make sure the response can be integrated into the text.
 - Your response should be in plain text i.e., do not use Markdown.
 - Do not include an introduction, summary, or conclusion.
-- Report dates in the format "Month YYYY" (e.g., June 2022), unless referring to the child's age of development stage (e.g. during adolesence).
+- If both month and year are provided, report dates as "Month YYYY" (e.g., June 2022). If the month is not provided, use only the year. The exception to this rule is references to the child's development stage (e.g. during adolesence).
 - Do not include an initial message in the response like "Based on the parent input provided here is a suggested completion" or a header like "Excerpt:" or "Parent Input"
 - Do not extrapolate from the source material; i.e. only include information that is stated in the source material.
 - If acronyms are used, maintain the acronyms; do not guess at the meaning of the acronym.


### PR DESCRIPTION
> I’ve noticed the CTK adds months (usually January or December) when parent only puts a year for when treatment start/end. For example, if a parent says 2021 to 2022, CTK will say January 2021 to December 2022. Can we remove months in these cases and only put year. Clinician can follow-up about this during the appointment to get clarity if needed.

This PR attempts to address this feedback; it adds an explicit instruction to the LLM to only use "Month YYYY" if the Month is available, else use YYYY.  For good measure, it also adds chain of verification to the past therapeutic interventions.