### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,6 @@
 name: Python Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/childmindresearch/ctk-functions/security/code-scanning/11](https://github.com/childmindresearch/ctk-functions/security/code-scanning/11)

To fix the issue, we will add a `permissions` block at the workflow level to define the least privileges required. Based on the workflow's steps, the minimal permissions required are `contents: read`. This will ensure that the `GITHUB_TOKEN` has only the necessary permissions to perform the actions in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
