### PR TITLE
Cache report template doc

### DIFF
--- a/src/ctk_functions/routers/intake/intake_processing/writer.py
+++ b/src/ctk_functions/routers/intake/intake_processing/writer.py
@@ -34,6 +34,7 @@ COMMENT_AUTHOR = "Clinician Toolkit"
 
 
 logger = config.get_logger()
+_TEMPLATE_DOCUMENT = docx.Document(str(DATA_DIR / "report_template.docx"))
 
 
 class _RGB(enum.Enum):
@@ -81,9 +82,8 @@ class ReportWriter:
         """
         logger.debug("Initializing the report writer.")
         self.intake = intake
-        self.report = cmi_docx.ExtendDocument(
-            docx.Document(str(DATA_DIR / "report_template.docx")),
-        )
+        template_copy = copy.deepcopy(_TEMPLATE_DOCUMENT)
+        self.report = cmi_docx.ExtendDocument(template_copy)
         self.enabled_tasks = enabled_tasks or EnabledTasks()
         self.insert_before = next(
             paragraph

--- a/tests/unit/test_intake_writer.py
+++ b/tests/unit/test_intake_writer.py
@@ -137,3 +137,19 @@ def test_set_superscript() -> None:
     assert document.paragraphs[0].runs[1].text == "st"
     assert document.paragraphs[0].runs[2].text == " time."
     assert document.paragraphs[0].runs[1].font.superscript
+
+
+def test_template_document_not_modified_between_instances() -> None:
+    """ReportWriter instances should not mutate the cached template."""
+    intake = MockIntake()
+
+    original_len = len(writer._TEMPLATE_DOCUMENT.paragraphs)
+
+    first = writer.ReportWriter(intake)
+    first.report.document.add_paragraph("extra")
+
+    second = writer.ReportWriter(intake)
+
+    assert len(writer._TEMPLATE_DOCUMENT.paragraphs) == original_len
+    assert len(second.report.document.paragraphs) == original_len
+    assert second.report.document is not writer._TEMPLATE_DOCUMENT


### PR DESCRIPTION
## Summary
- cache `report_template.docx` at module load
- copy the cached template in `ReportWriter.__init__`
- add regression test for template caching behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_mock')*

------
https://chatgpt.com/codex/tasks/task_e_685eda4eac4c832595ac236eb2e52db9