### PR TITLE
Reuse aiohttp sessions for language tool

### DIFF
--- a/src/ctk_functions/routers/intake/intake_processing/utils/language_utils.py
+++ b/src/ctk_functions/routers/intake/intake_processing/utils/language_utils.py
@@ -55,9 +55,13 @@ class DocumentCorrections:
 
     async def correct(self) -> None:
         """Makes corrections based on the enabled and disabled rules."""
-        await asyncio.gather(
-            *[self._correct_paragraph(para) for para in self.document.paragraphs],
-        )
+        async with self.correcter:
+            await asyncio.gather(
+                *[
+                    self._correct_paragraph(para)
+                    for para in self.document.paragraphs
+                ],
+            )
 
     async def _correct_paragraph(self, para: paragraph.Paragraph) -> None:
         """Corrects conjugations in a single paragraph.

--- a/src/ctk_functions/routers/language_tool/controller.py
+++ b/src/ctk_functions/routers/language_tool/controller.py
@@ -16,8 +16,8 @@ async def run_language_tool(body: schemas.PostLanguageToolRequest) -> str:
     Returns:
         The corrected text.
     """
-    correcter = language_tool.LanguageCorrecter(
+    async with language_tool.LanguageCorrecter(
         body.rules,
         settings.LANGUAGE_TOOL_URL,
-    )
-    return await correcter.correct(body.text)
+    ) as correcter:
+        return await correcter.correct(body.text)

--- a/tests/integration/test_language_utils.py
+++ b/tests/integration/test_language_utils.py
@@ -1,18 +1,25 @@
 """Integration tests (with LanguageTool) for document corrections."""
 
+import aiohttp
 import docx
 import pytest
+import pytest_mock
 
 from ctk_functions.routers.intake.intake_processing.utils import language_utils
 
 
 @pytest.mark.asyncio
-async def test_document_corrections() -> None:
+async def test_document_corrections(mocker: pytest_mock.MockerFixture) -> None:
     """Tests the DocumentCorrections class happy path.
 
     These runs are directly copied from a real paragraph in the test document, with
     the name/pronouns filled in as Lea she/her.
     """
+    session_spy = mocker.patch(
+        "ctk_functions.microservices.language_tool.aiohttp.ClientSession",
+        wraps=aiohttp.ClientSession,
+    )
+
     document = docx.Document()
     run_texts = [
         "At the standardized testing sessions,",
@@ -74,5 +81,6 @@ async def test_document_corrections() -> None:
     correcter = language_utils.DocumentCorrections(document)
 
     await correcter.correct()
+    assert session_spy.call_count == 1
 
     assert paragraph.text == full_text.replace("she", "She")

--- a/tests/integration/test_text_corrections.py
+++ b/tests/integration/test_text_corrections.py
@@ -6,9 +6,9 @@ from ctk_functions.microservices import language_tool
 
 
 @pytest.fixture(scope="module")
-def correcter() -> language_tool.LanguageCorrecter:
+async def correcter() -> language_tool.LanguageCorrecter:
     """Fixture for the LanguageCorrecter class."""
-    return language_tool.LanguageCorrecter(
+    async with language_tool.LanguageCorrecter(
         url="http://0.0.0.0:8010/v2",
         enabled_rules=[
             "PERS_PRONOUN_AGREEMENT",
@@ -16,7 +16,8 @@ def correcter() -> language_tool.LanguageCorrecter:
             "NON3PRS_VERB",
             "COMMA_COMPOUND_SENTENCE_2",
         ],
-    )
+    ) as correcter:
+        yield correcter
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- reuse one `aiohttp.ClientSession` inside `LanguageCorrecter`
- close the session with async context manager
- update document correction helper and endpoint controller
- adjust language tool integration tests to use async fixtures
- test that only a single session is created when correcting a document
- add missing type hints and docstrings for the new async context methods

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_mock')*


------
https://chatgpt.com/codex/tasks/task_e_685eda462c0083259eb82c08578a56c8